### PR TITLE
CPU support for pre-trained models. Working fine without issue.

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -26,8 +26,8 @@ class Inference():
         if args.multi_gpu:
             self.model = nn.DataParallel(self.model).to(self.device)
 
-        path = load_pretrained(f'TE-{args.arch}')
-        self.model.load_state_dict(path)
+        path = load_pretrained(f'TE-{args.arch}', self.device)
+        self.model.load_state_dict(path, strict = False)
         print('###### pre-trained Model restored #####')
 
         te_img_folder = os.path.join(args.data_path, args.dataset)

--- a/inference.py
+++ b/inference.py
@@ -23,11 +23,11 @@ class Inference():
 
         # Network
         self.model = TRACER(args).to(self.device)
-        if args.multi_gpu:
+        if args.multi_gpu or self.device.type == 'cpu': # original code does not infer with CPU conditions because it was saved with nn.DataParallel
             self.model = nn.DataParallel(self.model).to(self.device)
 
         path = load_pretrained(f'TE-{args.arch}', self.device)
-        self.model.load_state_dict(path, strict = False)
+        self.model.load_state_dict(path)
         print('###### pre-trained Model restored #####')
 
         te_img_folder = os.path.join(args.data_path, args.dataset)

--- a/modules/att_modules.py
+++ b/modules/att_modules.py
@@ -9,8 +9,9 @@ import torch.nn.functional as F
 from config import getConfig
 from modules.conv_modules import BasicConv2d, DWConv, DWSConv
 
-cfg = getConfig()
 
+cfg = getConfig()
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 class Frequency_Edge_Module(nn.Module):
     def __init__(self, radius, channel):
@@ -64,7 +65,7 @@ class Frequency_Edge_Module(nn.Module):
         x_fft = fftshift(x_fft)
 
         # Mask -> low, high separate
-        mask = self.mask_radial(img=x, r=self.radius).cuda()
+        mask = self.mask_radial(img=x, r=self.radius).to(device)
         high_frequency = x_fft * (1 - mask)
         x_fft = ifftshift(high_frequency)
         x_fft = ifft2(x_fft, dim=(-2, -1))

--- a/trainer.py
+++ b/trainer.py
@@ -159,7 +159,7 @@ class Trainer():
 
     def test(self, args, save_path):
         path = os.path.join(save_path, 'best_model.pth')
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path, map_location = self.device))
         print('###### pre-trained Model restored #####')
 
         te_img_folder = os.path.join(args.data_path, args.dataset, 'Test/images/')
@@ -226,7 +226,7 @@ class Tester():
             self.model = nn.DataParallel(self.model).to(self.device)
 
         path = os.path.join(save_path, 'best_model.pth')
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path, map_location = self.device))
         print('###### pre-trained Model restored #####')
 
         self.criterion = Criterion(args)

--- a/util/effi_utils.py
+++ b/util/effi_utils.py
@@ -616,12 +616,13 @@ def load_pretrained_weights(model, model_name, weights_path=None, load_fc=True, 
         advprop (bool): Whether to load pretrained weights
                         trained with advprop (valid when weights_path is None).
     """
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     if isinstance(weights_path, str):
-        state_dict = torch.load(weights_path, strict=False)
+        state_dict = torch.load(weights_path, strict=False, map_location = device)
     else:
         # AutoAugment or Advprop (different preprocessing)
         url_map_ = url_map_advprop if advprop else url_map
-        state_dict = model_zoo.load_url(url_map_[model_name])
+        state_dict = model_zoo.load_url(url_map_[model_name], map_location=device)
 
     if load_fc:
         ret = model.load_state_dict(state_dict, strict=False)

--- a/util/utils.py
+++ b/util/utils.py
@@ -43,7 +43,7 @@ url_TRACER = {
 }
 
 
-def load_pretrained(model_name):
-    state_dict = model_zoo.load_url(url_TRACER[model_name])
+def load_pretrained(model_name, device):
+    state_dict = model_zoo.load_url(url_TRACER[model_name], map_location = device)
 
     return state_dict

--- a/w.o_edges/trainer.py
+++ b/w.o_edges/trainer.py
@@ -156,7 +156,7 @@ class Trainer():
 
     def test(self, args, save_path):
         path = os.path.join(save_path, 'best_model.pth')
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path, map_location=self.device))
         print('###### pre-trained Model restored #####')
 
         te_img_folder = os.path.join(args.data_path, args.dataset, 'Test/images/')
@@ -223,7 +223,7 @@ class Tester():
             self.model = nn.DataParallel(self.model).to(self.device)
 
         path = os.path.join(save_path, 'best_model.pth')
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path, map_location=self.device))
         print('###### pre-trained Model restored #####')
 
         self.criterion = Criterion(args)


### PR DESCRIPTION
Hi, 
There was a line where it was directly written as `.cuda()` to push the structure to GPU. I have changes it to `.to(device)`.

Since the models were trained with `cuda` GPUs and saved with `nn.DataParallel`, they are not able to load in CPU. I have change just a couple of lines such as allocating the `map_location` where ever necessary. Also, just for the pre-trained models, which most of the users will be loading, I have added one more condition that loads the models and gives results smoothly. Please let me know if I could do some other changes.